### PR TITLE
ability to bind to non-observable

### DIFF
--- a/knockout-tinymce.coffee
+++ b/knockout-tinymce.coffee
@@ -44,7 +44,7 @@
       # tiny mce crashes if value is null
       if value == null
         value = ""
-      if tinymce and cacheInstance == tinymce and cache != value
+      if tinymce and not (cacheInstance == tinymce and cache == value)
         cacheInstance = tinymce
         cache = value
         if tinymce.getContent() isnt value

--- a/knockout-tinymce.coffee
+++ b/knockout-tinymce.coffee
@@ -45,6 +45,14 @@
           tinymce.setContent value
       return
 
+  writeValueToProperty = (property, allBindings, key, value, checkIfDifferent) -> 
+    if !property or !ko.isObservable property
+      propWriters = allBindings.get '_ko_property_writers'
+      propWriters[key](value) if propWriters && propWriters[key]
+    else if ko.isWriteableObservable(property) and (!checkIfDifferent or property.peek() != value)
+        property value
+    
+
   configure = (defaults, extensions, options, args) ->
 
     # Apply global configuration over TinyMCE defaults
@@ -72,7 +80,7 @@
       editor.on "change keyup nodechange", (e) ->
 
         # Update the view model
-        ko.expressionRewriting.writeValueToProperty(args[1](), args[2], "tinymce", editor.getContent())
+        writeValueToProperty(args[1](), args[2], "tinymce", editor.getContent())
 
         # Run all applied extensions
         for name of extensions
@@ -98,6 +106,6 @@
 
   # Export the binding
   ko.bindingHandlers["tinymce"] = binding
-  ko.expressionRewriting.twoWayBindings["tinymce"] = true;
+  ko.expressionRewriting._twoWayBindings["tinymce"] = true;
   return
 ) jQuery, ko

--- a/knockout-tinymce.coffee
+++ b/knockout-tinymce.coffee
@@ -1,5 +1,6 @@
 (($, ko) ->
   cache = ""
+  cacheInstance = null
   binding =
     after: [
       "attr"
@@ -30,6 +31,7 @@
       ko.utils["domNodeDisposal"].addDisposeCallback element, ->
         tinymce = $(element).tinymce()
         tinymce.remove() if tinymce
+        cacheInstance = null unless tinymce != cacheInstance
         return
 
       controlsDescendantBindings: true
@@ -42,7 +44,9 @@
       # tiny mce crashes if value is null
       if value == null
         value = ""
-      if tinymce and cache != value
+      if tinymce and cacheInstance == tinymce and cache != value
+        cacheInstance = tinymce
+        cache = value
         if tinymce.getContent() isnt value
           tinymce.setContent value
       return
@@ -84,6 +88,7 @@
         setTimeout (->
           value = editor.getContent()
           cache = value
+          cacheInstance = editor
           
           # Update the view model
           writeValueToProperty args[1](), args[2], "tinymce", value

--- a/knockout-tinymce.coffee
+++ b/knockout-tinymce.coffee
@@ -79,13 +79,15 @@
       # Ensure the valueAccessor state to achieve a realtime responsive UI.
       editor.on "change keyup nodechange", (e) ->
 
-        # Update the view model
-        writeValueToProperty(args[1](), args[2], "tinymce", editor.getContent())
+        setTimeout (->
+          # Update the view model
+          writeValueToProperty(args[1](), args[2], "tinymce", editor.getContent())
 
-        # Run all applied extensions
-        for name of extensions
-          binding["extensions"][extensions[name]] editor, e, args[2], args[4]  if extensions.hasOwnProperty(name)
-        return
+          # Run all applied extensions
+          for name of extensions
+            binding["extensions"][extensions[name]] editor, e, args[2], args[4]  if extensions.hasOwnProperty(name)
+          return
+        ), 0
 
       return
 

--- a/knockout-tinymce.coffee
+++ b/knockout-tinymce.coffee
@@ -7,7 +7,6 @@
     defaults: {}
     extensions: {}
     init: (element, valueAccessor, allBindings, viewModel, bindingContext) ->
-      throw "valueAccessor must be writeable and observable"  unless ko.isWriteableObservable(valueAccessor())
 
       # Get custom configuration object from the 'wysiwygConfig' binding, more settings here... http://www.tinymce.com/wiki.php/Configuration
       options = (if allBindings.has("tinymceConfig") then allBindings.get("tinymceConfig") else null)
@@ -17,7 +16,7 @@
       settings = configure(binding["defaults"], ext, options, arguments)
 
       # Ensure the valueAccessor's value has been applied to the underlying element, before instanciating the tinymce plugin
-      $(element)[if $(element).is('input, textarea') then 'text' else 'html'] valueAccessor()()
+      $(element)[if $(element).is('input, textarea') then 'text' else 'html'] ko.unwrap(valueAccessor())
 
       # Defer TinyMCE instantiation
       setTimeout (->
@@ -72,8 +71,8 @@
       # Ensure the valueAccessor state to achieve a realtime responsive UI.
       editor.on "change keyup nodechange", (e) ->
 
-        # Update the valueAccessor
-        args[1]() editor.getContent()
+        # Update the view model
+        ko.expressionRewriting.writeValueToProperty(args[1](), args[2], "tinymce", editor.getContent())
 
         # Run all applied extensions
         for name of extensions
@@ -99,5 +98,6 @@
 
   # Export the binding
   ko.bindingHandlers["tinymce"] = binding
+  ko.expressionRewriting.twoWayBindings["tinymce"] = true;
   return
 ) jQuery, ko


### PR DESCRIPTION
Implemented the way the standard knockout bindings update values, which also updates plain properties if they're not observable.

This is needed to use the binding with knockout-es5 properties.
